### PR TITLE
fix: set pydantic json mode to serialization

### DIFF
--- a/drf_spectacular/contrib/pydantic.py
+++ b/drf_spectacular/contrib/pydantic.py
@@ -34,7 +34,7 @@ class PydanticExtension(OpenApiSerializerExtension):
             warn("Only pydantic >= 2 is supported. defaulting to generic object.")
             return build_basic_type(OpenApiTypes.OBJECT)
 
-        schema = model_json_schema(self.target, ref_template="#/components/schemas/{model}")
+        schema = model_json_schema(self.target, ref_template="#/components/schemas/{model}", mode="serialization")
 
         # pull out potential sub-schemas and put them into component section
         for sub_name, sub_schema in schema.pop("$defs", {}).items():

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -1,4 +1,5 @@
 import sys
+from decimal import Decimal
 from typing import List
 
 import pytest
@@ -31,6 +32,7 @@ class B(BaseModel):
 class A(BaseModel):
     id: int
     b: B
+    d: Decimal
 
 
 @pytest.mark.contrib('pydantic')

--- a/tests/contrib/test_pydantic.yml
+++ b/tests/contrib/test_pydantic.yml
@@ -40,9 +40,13 @@ components:
           type: integer
         b:
           $ref: '#/components/schemas/B'
+        d:
+          title: D
+          type: string
       required:
       - id
       - b
+      - d
       title: A
       type: object
     B:


### PR DESCRIPTION
See: https://github.com/pydantic/pydantic/issues/7457#issuecomment-1732032174

This fixes the schema for Decimal types.

Before:

```yml

d:
  anyOf:
  - type: number
  - type: string
  title: D
  type: string
```


After:

```yml
d:
  title: D
  type: string
```

